### PR TITLE
Bugfix 포스트수정 오류 수정

### DIFF
--- a/src/app/api/v1/image/uploadFile/route.js
+++ b/src/app/api/v1/image/uploadFile/route.js
@@ -59,6 +59,8 @@ async function POST(request) {
       fileBuffer = Buffer.concat([fileBuffer, chunk]);
     }
 
+    await s3Data.putObject(s3Params);
+
     const fileUrl = `https://${bucketName}.s3.amazonaws.com/${fileName}`;
 
     return NextResponse.json({

--- a/src/app/post/editor/[userId]/page.jsx
+++ b/src/app/post/editor/[userId]/page.jsx
@@ -13,7 +13,7 @@ function PostEditPage({ params }) {
   const [content, setContent] = useState({});
   const [error, setError] = useState(null);
 
-  const userId = params[0];
+  const userId = Array.isArray(params) ? params[0] : params.userId;
   const postId = params[1] || null;
 
   const isModify = Boolean(postId);

--- a/src/app/post/editor/[userId]/page.jsx
+++ b/src/app/post/editor/[userId]/page.jsx
@@ -13,8 +13,8 @@ function PostEditPage({ params }) {
   const [content, setContent] = useState({});
   const [error, setError] = useState(null);
 
-  const userId = params.userId;
-  const postId = params.postId || null;
+  const userId = params[0];
+  const postId = params[1] || null;
 
   const isModify = Boolean(postId);
 

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -12,27 +12,28 @@ function Editor({ author, postId, title, content, error, setError, isModify }) {
 
   useEffect(() => {
     const initEditor = async () => {
-      if (!ref.current) {
-        ref.current = new EditorJS({
-          holder: 'editorjs',
-          data: content,
-          tools: {
-            image: {
-              class: ImageTool,
-              config: {
-                endpoints: {
-                  byFile: 'http://localhost:3000/api/v1/image/uploadFile',
-                },
-                types: 'image/*',
-                captionPlaceholder: 'Enter caption',
-              },
-            },
-          },
-        });
-      } else {
+      if (ref.current) {
         await ref.current.isReady;
         ref.current.render(content);
+        return;
       }
+
+      ref.current = new EditorJS({
+        holder: 'editorjs',
+        data: content,
+        tools: {
+          image: {
+            class: ImageTool,
+            config: {
+              endpoints: {
+                byFile: 'http://localhost:3000/api/v1/image/uploadFile',
+              },
+              types: 'image/*',
+              captionPlaceholder: 'Enter caption',
+            },
+          },
+        },
+      });
     };
 
     initEditor();
@@ -53,13 +54,9 @@ function Editor({ author, postId, title, content, error, setError, isModify }) {
     };
 
     try {
-      let response = {};
-
-      if (isModify) {
-        response = await axios.put(`/api/v1/posts/${postId}`, postData);
-      } else {
-        response = await axios.post('/api/v1/posts', postData);
-      }
+      const response = isModify
+        ? await axios.put(`/api/v1/posts/${postId}`, postData)
+        : await axios.post('/api/v1/posts', postData);
 
       if (response.data.status !== 'success') {
         setError(response.data.message);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -11,34 +11,31 @@ function Editor({ author, postId, title, content, error, setError, isModify }) {
   const router = useRouter();
 
   useEffect(() => {
-    if (ref.current) {
-      return;
-    }
-
-    const editor = new EditorJS({
-      holder: 'editorjs',
-      data: content,
-      tools: {
-        image: {
-          class: ImageTool,
-          config: {
-            endpoints: {
-              byFile: 'http://localhost:3000/api/v1/image/uploadFile',
+    const initEditor = async () => {
+      if (!ref.current) {
+        ref.current = new EditorJS({
+          holder: 'editorjs',
+          data: content,
+          tools: {
+            image: {
+              class: ImageTool,
+              config: {
+                endpoints: {
+                  byFile: 'http://localhost:3000/api/v1/image/uploadFile',
+                },
+                types: 'image/*',
+                captionPlaceholder: 'Enter caption',
+              },
             },
-            types: 'image/*',
-            captionPlaceholder: 'Enter caption',
           },
-        },
-      },
-    });
-
-    ref.current = editor;
-
-    return () => {
-      if (ref.current && typeof ref.current.destroy === 'function') {
-        ref.current.destroy();
+        });
+      } else {
+        await ref.current.isReady;
+        ref.current.render(content);
       }
     };
+
+    initEditor();
   }, [content]);
 
   const postSave = async () => {

--- a/src/components/postlist/PostItem.jsx
+++ b/src/components/postlist/PostItem.jsx
@@ -14,7 +14,7 @@ function PostItem({ post }) {
   return (
     <div className='w-56 h-56 flex flex-col items-center justify-center bg-slate-300'>
       {imageUrl ? (
-        <div className='h-4/5'>
+        <div className='h-4/5 w-56 h-56 overflow-hidden relative'>
           <Image src={imageUrl} alt={textValue} width={224} height={224} />
         </div>
       ) : (

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -38,6 +38,11 @@ const SIGNED_URL_CREATION_ERROR = {
   MESSAGE: 'signed URL 생성 오류입니다.',
 };
 
+const FILE_NOT_FOUND = {
+  STATUS_CODE: 400, // 예: 400은 잘못된 요청을 나타냅니다.
+  MESSAGE: '요청에서 파일을 찾을 수 없습니다.',
+};
+
 export const ERRORS = {
   INVALID_USER_ID,
   USER_NOT_FOUND,
@@ -47,4 +52,5 @@ export const ERRORS = {
   MISSING_PARAMETERS,
   POST_NOT_FOUND,
   SIGNED_URL_CREATION_ERROR,
+  FILE_NOT_FOUND,
 };


### PR DESCRIPTION
## 📝 PR 목적
포스트 수정 관련 포스트 생성 컴포넌트 및 이미지 저장 API 오류 수정 작업  #18 

https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133579214/b6936369-9886-4d76-bd85-29752bdda4d6

## 📑 작업 내용
- page.jsx 디렉토리 설정에 따라 params 불러오는 방식 변경 #18 ([위치](https://github.com/Last-Survivors-3-8/VanilLog-client/compare/bugfix-%ED%8F%AC%EC%8A%A4%ED%8A%B8%EC%88%98%EC%A0%95-%EC%98%A4%EB%A5%98-%EC%88%98%EC%A0%95?expand=1#diff-9df749b078a156e07c246526b3068c3bd04b939d50d62944851f17865a69671cR16))
  - 기존 : app/post/editor/[...editId]/page.jsx
  - 변경 : app/post/editor/[userId]/page.jsx, app/post/editor/[userId]/[postId]/page.jsx
- editor 컴포넌트 기존 포스트 editor.js로 불러오는 부분 수정 ([위치](https://github.com/Last-Survivors-3-8/VanilLog-client/compare/dev...bugfix-%ED%8F%AC%EC%8A%A4%ED%8A%B8%EC%88%98%EC%A0%95-%EC%98%A4%EB%A5%98-%EC%88%98%EC%A0%95#diff-9b236b1937ff5f05a6b5fc3f2e8617684bf19d961b50c44529684d70651dc592R14))
  - 이전 
    - content가 변경될 때마다 EditorJS가 초기화되어 렌더링이 제대로 되지 않는 오류 발생
  - 수정
    - EditorJS가 이미 있으면 재사용하여 기존 EditorJS에 데이터를 렌더링
    - await ref.current.isReady를 사용하여 EditorJS 렌더링 준비를 기다린 후 데이터 렌더링
- S3 이미지 업로드 API 수정 ([위치](https://github.com/Last-Survivors-3-8/VanilLog-client/compare/bugfix-%ED%8F%AC%EC%8A%A4%ED%8A%B8%EC%88%98%EC%A0%95-%EC%98%A4%EB%A5%98-%EC%88%98%EC%A0%95?expand=1#diff-558bd1245b10755116d5c843a2eda2abff09323dd80bcfdc46c0864971cd90dbR72))
  - 코드를 정리하다가 잘못 제거하여 오류 발생 (수정이 되면 테스트를 꼼꼼히 하겠습니다.)

## 🚧 주의 사항

