### PR TITLE
Feature 댓글 생성, 조회 api 구현 및 댓글 목록 컴포넌트 구현

### DIFF
--- a/models/Comment.js
+++ b/models/Comment.js
@@ -6,7 +6,7 @@ const CommentSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       auto: true,
     },
-    blogPost: { type: mongoose.Schema.Types.ObjectId, ref: 'BlogPost' },
+    blogPost: { type: mongoose.Schema.Types.ObjectId, ref: 'Post' },
     author: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',

--- a/models/User.js
+++ b/models/User.js
@@ -7,7 +7,7 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true },
     socialLoginType: { type: String, enum: ['facebook', 'google', 'twitter'] },
     profileImage: { type: String },
-    blogPosts: [{ type: mongoose.Schema.Types.ObjectId, ref: 'BlogPost' }],
+    blogPosts: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Post' }],
     comments: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Comment' }],
   },
   { timestamps: true },

--- a/src/app/api/v1/comment/[postId]/route.js
+++ b/src/app/api/v1/comment/[postId]/route.js
@@ -1,0 +1,106 @@
+import createError from 'http-errors';
+import { NextResponse } from 'next/server';
+
+import dbConnect from '@lib/dbConnect';
+import Post from '@models/Post';
+import User from '@models/User';
+import Comment from '@models/Comment';
+import { ERRORS } from '@utils/errors';
+import { sendErrorResponse } from '@utils/response';
+import { validateObjectId } from '@utils/validateObjectId';
+import { getLastPartOfUrl } from '@utils/getLastPartOfUrl';
+
+/**
+ * 댓글 생성 API
+ * @URL /api/v1/comment/:postId
+ * @param request
+ */
+async function POST(request) {
+  await dbConnect();
+
+  try {
+    const postId = getLastPartOfUrl(request.url);
+    validateObjectId(postId);
+
+    const { comment, author } = await request.json();
+
+    if (!comment || !author) {
+      throw createError(
+        ERRORS.MISSING_PARAMETERS.STATUS_CODE,
+        ERRORS.MISSING_PARAMETERS.MESSAGE,
+      );
+    }
+
+    validateObjectId(author);
+
+    const postExists = await Post.findById(postId).lean().exec();
+    if (!postExists) {
+      throw createError(
+        ERRORS.POST_NOT_FOUND.STATUS_CODE,
+        ERRORS.POST_NOT_FOUND.MESSAGE,
+      );
+    }
+
+    const newComment = await Comment.create({
+      comment,
+      author,
+      blogPost: postId,
+    });
+
+    await Post.findByIdAndUpdate(
+      postId,
+      { $push: { comments: newComment._id } },
+      { new: true, useFindAndModify: false },
+    );
+
+    await User.findByIdAndUpdate(
+      author,
+      { $push: { comments: newComment._id } },
+      { new: true, useFindAndModify: false },
+    );
+
+    return NextResponse.json({
+      status: 'success',
+      data: newComment,
+    });
+  } catch (error) {
+    return sendErrorResponse(error);
+  }
+}
+
+/**
+ * 댓글 조회 API
+ * @URL /api/v1/comment/:postId
+ * @param request
+ */
+async function GET(request) {
+  await dbConnect();
+
+  try {
+    const postId = getLastPartOfUrl(request.url);
+    validateObjectId(postId);
+
+    const postExists = await Post.findById(postId).lean().exec();
+    if (!postExists) {
+      throw createError(
+        ERRORS.POST_NOT_FOUND.STATUS_CODE,
+        ERRORS.POST_NOT_FOUND.MESSAGE,
+      );
+    }
+
+    const comments = await Comment.find({
+      _id: { $in: postExists.comments },
+    })
+      .lean()
+      .exec();
+
+    return NextResponse.json({
+      status: 'success',
+      data: comments,
+    });
+  } catch (error) {
+    return sendErrorResponse(error);
+  }
+}
+
+export { POST, GET };

--- a/src/app/api/v1/comment/[postId]/route.js
+++ b/src/app/api/v1/comment/[postId]/route.js
@@ -20,8 +20,6 @@ async function POST(request) {
 
   try {
     const postId = getLastPartOfUrl(request.url);
-    validateObjectId(postId);
-
     const { comment, author } = await request.json();
 
     if (!comment || !author) {
@@ -31,9 +29,10 @@ async function POST(request) {
       );
     }
 
+    validateObjectId(postId);
     validateObjectId(author);
 
-    const postExists = await Post.findById(postId).lean().exec();
+    const postExists = await Post.exists({ _id: postId });
     if (!postExists) {
       throw createError(
         ERRORS.POST_NOT_FOUND.STATUS_CODE,
@@ -80,8 +79,8 @@ async function GET(request) {
     const postId = getLastPartOfUrl(request.url);
     validateObjectId(postId);
 
-    const postExists = await Post.findById(postId).lean().exec();
-    if (!postExists) {
+    const currentPost = await Post.findById(postId).lean().exec();
+    if (!currentPost) {
       throw createError(
         ERRORS.POST_NOT_FOUND.STATUS_CODE,
         ERRORS.POST_NOT_FOUND.MESSAGE,
@@ -89,7 +88,7 @@ async function GET(request) {
     }
 
     const comments = await Comment.find({
-      _id: { $in: postExists.comments },
+      _id: { $in: currentPost.comments },
     })
       .lean()
       .exec();

--- a/src/app/api/v1/comment/[postId]/route.js
+++ b/src/app/api/v1/comment/[postId]/route.js
@@ -33,6 +33,7 @@ async function POST(request) {
     validateObjectId(author);
 
     const postExists = await Post.exists({ _id: postId });
+
     if (!postExists) {
       throw createError(
         ERRORS.POST_NOT_FOUND.STATUS_CODE,
@@ -80,6 +81,7 @@ async function GET(request) {
     validateObjectId(postId);
 
     const currentPost = await Post.findById(postId).lean().exec();
+
     if (!currentPost) {
       throw createError(
         ERRORS.POST_NOT_FOUND.STATUS_CODE,

--- a/src/app/post/[userId]/[postId]/page.jsx
+++ b/src/app/post/[userId]/[postId]/page.jsx
@@ -1,4 +1,5 @@
 import PostDetail from '@src/components/PostDetail/PostDetail';
+import CommentsContainer from '@src/components/Comment/CommentsContainer';
 import { METAINFO } from '@utils/metaInfo';
 import axios from 'axios';
 
@@ -34,6 +35,7 @@ export default function PostDetailPage({ params }) {
   return (
     <div className='bg-gray-100 min-h-screen p-10'>
       <PostDetail userId={userId} postId={postId} />
+      <CommentsContainer postId={postId} />
     </div>
   );
 }

--- a/src/components/Comment/CommentsContainer.jsx
+++ b/src/components/Comment/CommentsContainer.jsx
@@ -28,11 +28,13 @@ function CommentsContainer({ postId }) {
     const fetchComments = async () => {
       try {
         const response = await axios.get(`/api/v1/comment/${postId}`);
+
         if (response.data.status === 'success') {
           setComments(response.data.data);
         }
       } catch (error) {}
     };
+
     fetchComments();
   }, [postId]);
 

--- a/src/components/Comment/CommentsContainer.jsx
+++ b/src/components/Comment/CommentsContainer.jsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useComments } from '@utils/useComment';
+import CommentsSection from '@src/components/Comment/CommentsSection';
+
+function CommentsContainer({ postId }) {
+  const {
+    commentText,
+    setCommentText,
+    handleCommentSubmit,
+    errorMessage: commentError,
+  } = useComments(postId);
+
+  const [comments, setComments] = useState([]);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const handleNewComment = async () => {
+    const newComment = await handleCommentSubmit();
+
+    if (newComment) {
+      setComments((prevComments) => [...prevComments, newComment]);
+    }
+  };
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        const response = await axios.get(`/api/v1/comment/${postId}`);
+        if (response.data.status === 'success') {
+          setComments(response.data.data);
+        }
+      } catch (error) {}
+    };
+    fetchComments();
+  }, [postId]);
+
+  useEffect(() => {
+    if (commentError) {
+      setErrorMessage(commentError);
+    }
+  }, [commentError]);
+
+  return (
+    <>
+      {errorMessage && <div>{errorMessage}</div>}
+      <CommentsSection
+        comments={comments}
+        commentText={commentText}
+        onCommentChange={(e) => setCommentText(e.target.value)}
+        onCommentSubmit={handleNewComment}
+      />
+    </>
+  );
+}
+
+export default CommentsContainer;

--- a/src/components/Comment/CommentsSection.jsx
+++ b/src/components/Comment/CommentsSection.jsx
@@ -10,8 +10,8 @@ function CommentsSection({
       {comments && comments.length ? (
         comments.map((comment) => (
           <div key={comment.id} className='border-t pt-4'>
-            <p className='mb-2'>{comment.text}</p>
-            <span className='text-gray-500'>작성자: {comment.author.name}</span>
+            <p className='mb-2'>{comment.comment}</p>
+            <span className='text-gray-500'>작성자: {comment.author}</span>
           </div>
         ))
       ) : (

--- a/src/components/Comment/CommentsSection.jsx
+++ b/src/components/Comment/CommentsSection.jsx
@@ -9,7 +9,7 @@ function CommentsSection({
       <h2 className='text-xl font-semibold mt-6 mb-4'>댓글</h2>
       {comments && comments.length ? (
         comments.map((comment) => (
-          <div key={comment.id} className='border-t pt-4'>
+          <div key={comment._id} className='border-t pt-4'>
             <p className='mb-2'>{comment.comment}</p>
             <span className='text-gray-500'>작성자: {comment.author}</span>
           </div>

--- a/src/components/PostDetail/PostDetail.jsx
+++ b/src/components/PostDetail/PostDetail.jsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import DeleteModal from './DeleteModal';
 import PostContent from './PostContent';
 import PostActions from './PostActions';
-import CommentsSection from './CommentsSection';
+import CommentsSection from '../Comment/CommentsSection';
 import ErrorMessageWindow from './ErrorMessageWindow';
 import { usePost } from '@utils/usePost';
 import { useComments } from '@utils/useComment';
@@ -46,8 +46,6 @@ export default function PostDetail({ userId, postId }) {
             onShowDeleteModal={() => setShowModal(true)}
           />
         )}
-
-        {/* 오류나는 컴포넌트 주석처리 <CommentsSection comments={post.comments} /> */}
       </div>
     </>
   );

--- a/src/components/PostDetail/PostDetail.jsx
+++ b/src/components/PostDetail/PostDetail.jsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import DeleteModal from './DeleteModal';
 import PostContent from './PostContent';
 import PostActions from './PostActions';
-import CommentsSection from '../Comment/CommentsSection';
 import ErrorMessageWindow from './ErrorMessageWindow';
 import { usePost } from '@utils/usePost';
 import { useComments } from '@utils/useComment';

--- a/utils/useComment.js
+++ b/utils/useComment.js
@@ -12,9 +12,8 @@ export const useComments = (postId) => {
   const handleError = (error) => {
     if (error.response && error.response.data.status !== 'success') {
       setErrorMessage(error.response.data.message);
-    } else {
-      setErrorMessage('알 수 없는 오류가 발생했습니다.');
     }
+    return setErrorMessage('알 수 없는 오류가 발생했습니다.');
   };
 
   const handleCommentSubmit = async () => {
@@ -31,12 +30,12 @@ export const useComments = (postId) => {
         comment: commentText,
         author: commentAuthorId,
       });
+
       if (response.data.status === 'success') {
         setCommentText('');
         return response.data.data;
-      } else {
-        handleError(response);
       }
+      return handleError(response);
     } catch (error) {
       handleError(error);
     }

--- a/utils/useComment.js
+++ b/utils/useComment.js
@@ -13,6 +13,7 @@ export const useComments = (postId) => {
     if (error.response && error.response.data.status !== 'success') {
       setErrorMessage(error.response.data.message);
     }
+
     return setErrorMessage('알 수 없는 오류가 발생했습니다.');
   };
 
@@ -20,6 +21,7 @@ export const useComments = (postId) => {
     if (!commentText) return;
 
     const commentAuthorId = session?.mongoId;
+
     if (!commentAuthorId) {
       setErrorMessage('로그인이 필요합니다.');
       return;
@@ -33,8 +35,10 @@ export const useComments = (postId) => {
 
       if (response.data.status === 'success') {
         setCommentText('');
+
         return response.data.data;
       }
+
       return handleError(response);
     } catch (error) {
       handleError(error);

--- a/utils/usePost.js
+++ b/utils/usePost.js
@@ -11,6 +11,7 @@ export const usePost = (postId) => {
     if (error.response && error.response.data.status !== 'success') {
       return setErrorMessage(error.response.data.message);
     }
+
     return setErrorMessage('알 수 없는 오류가 발생했습니다.');
   };
 
@@ -19,9 +20,11 @@ export const usePost = (postId) => {
       if (!postId) return;
       try {
         const response = await axios.get(`/api/v1/post/${postId}`);
+
         if (response.data.status === 'success') {
           return setPost(response.data.data);
         }
+
         return handleError(response);
       } catch (error) {
         return handleError(error);
@@ -33,9 +36,11 @@ export const usePost = (postId) => {
   const handleDelete = async (router, userId) => {
     try {
       const response = await axios.delete(`/api/v1/post/${postId}`);
+
       if (response.data.status === 'success') {
         return router.push(`/posts/${userId}`);
       }
+
       return handleError(response);
     } catch (error) {
       return handleError(error);

--- a/utils/usePost.js
+++ b/utils/usePost.js
@@ -9,10 +9,9 @@ export const usePost = (postId) => {
 
   const handleError = (error) => {
     if (error.response && error.response.data.status !== 'success') {
-      setErrorMessage(error.response.data.message);
-    } else {
-      setErrorMessage('알 수 없는 오류가 발생했습니다.');
+      return setErrorMessage(error.response.data.message);
     }
+    return setErrorMessage('알 수 없는 오류가 발생했습니다.');
   };
 
   useEffect(() => {
@@ -21,12 +20,11 @@ export const usePost = (postId) => {
       try {
         const response = await axios.get(`/api/v1/post/${postId}`);
         if (response.data.status === 'success') {
-          setPost(response.data.data);
-        } else {
-          handleError(response);
+          return setPost(response.data.data);
         }
+        return handleError(response);
       } catch (error) {
-        handleError(error);
+        return handleError(error);
       }
     };
     fetchPost();
@@ -36,12 +34,11 @@ export const usePost = (postId) => {
     try {
       const response = await axios.delete(`/api/v1/post/${postId}`);
       if (response.data.status === 'success') {
-        router.push(`/posts/${userId}`);
-      } else {
-        handleError(response);
+        return router.push(`/posts/${userId}`);
       }
+      return handleError(response);
     } catch (error) {
-      handleError(error);
+      return handleError(error);
     }
   };
 


### PR DESCRIPTION
## 📝 PR 목적

댓글을 작성하면 댓글 목록에 바로 보여지며 각 연관된 db에 oid가 참조됨.

## 📑 작업 내용
- [x] 댓글 작성 시 포스트 아래 목록에 나타남.
![image](https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133510836/19249fc4-f83b-49d5-ad70-4eaccdfada52)

- [x] 댓글 작성 시 DB 저장 (댓글이 작성된 포스트와 댓글 작성자의 oid 참조)
![image](https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133510836/27918594-bb5c-4a5f-a616-ac335e14b614)
 
- [x] 댓글 작성 시 Post DB에도 저장
![image](https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133510836/970a98a7-091d-429e-a7ae-dfb6c11bb90b)

## 🚧 주의 사항
useState로 댓글 작성 시 바로 나타납니다.
삭제 및 수정 기능은 구현하지 않았습니다.