### PR TITLE
Feature 댓글 삭제 api

### DIFF
--- a/src/app/api/v1/comment/[postId]/[commentId]/route.js
+++ b/src/app/api/v1/comment/[postId]/[commentId]/route.js
@@ -1,0 +1,78 @@
+import createError from 'http-errors';
+import { NextResponse } from 'next/server';
+
+import dbConnect from '@lib/dbConnect';
+import Post from '@models/Post';
+import User from '@models/User';
+import Comment from '@models/Comment';
+import { ERRORS } from '@utils/errors';
+import { sendErrorResponse } from '@utils/response';
+import { validateObjectId } from '@utils/validateObjectId';
+import { getLastPartOfUrl } from '@utils/getLastPartOfUrl';
+import { getSessionFromRequest } from '@utils/getSessionFromRequest';
+
+/**
+ * 댓글 삭제 API
+ * @URL /api/v1/comment/:postId/:commentId
+ * @param request
+ */
+async function DELETE(request) {
+  await dbConnect();
+
+  try {
+    const session = await getSessionFromRequest(request);
+
+    if (!session) {
+      throw createError(
+        ERRORS.COMMENT_USER_NOT_LOGGED_IN.STATUS_CODE,
+        ERRORS.COMMENT_USER_NOT_LOGGED_IN.MESSAGE,
+      );
+    }
+
+    const currentUserId = session.mongoId;
+    const commentId = getLastPartOfUrl(request.url);
+    validateObjectId(commentId);
+
+    const comment = await Comment.findById(commentId);
+
+    if (!comment) {
+      throw createError(
+        ERRORS.COMMENT_NOT_FOUND.STATUS_CODE,
+        ERRORS.COMMENT_NOT_FOUND.MESSAGE,
+      );
+    }
+
+    const postId = comment.blogPost;
+    const authorId = comment.author.toHexString();
+
+    if (currentUserId !== authorId) {
+      throw createError(
+        ERRORS.NOT_COMMENT_AUTHOR.STATUS_CODE,
+        ERRORS.NOT_COMMENT_AUTHOR.MESSAGE,
+      );
+    }
+
+    await Comment.findByIdAndDelete(commentId);
+
+    await Post.findByIdAndUpdate(
+      postId,
+      { $pull: { comments: commentId } },
+      { new: true, useFindAndModify: false },
+    );
+
+    await User.findByIdAndUpdate(
+      authorId,
+      { $pull: { comments: commentId } },
+      { new: true, useFindAndModify: false },
+    );
+
+    return NextResponse.json({
+      status: 'success',
+      message: 'Comment deleted successfully.',
+    });
+  } catch (error) {
+    return sendErrorResponse(error);
+  }
+}
+
+export { DELETE };

--- a/src/app/api/v1/comment/[postId]/[commentId]/route.js
+++ b/src/app/api/v1/comment/[postId]/[commentId]/route.js
@@ -43,7 +43,7 @@ async function DELETE(request) {
     }
 
     const postId = comment.blogPost;
-    const authorId = comment.author.toHexString();
+    const authorId = comment.author.toString();
 
     if (currentUserId !== authorId) {
       throw createError(

--- a/src/app/api/v1/comment/[postId]/[commentId]/route.js
+++ b/src/app/api/v1/comment/[postId]/[commentId]/route.js
@@ -31,6 +31,7 @@ async function DELETE(request) {
 
     const currentUserId = session.mongoId;
     const commentId = getLastPartOfUrl(request.url);
+
     validateObjectId(commentId);
 
     const comment = await Comment.findById(commentId);

--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import axios from 'axios';
+import { useSession } from 'next-auth/react';
+
+function Comment({ commentInfo }) {
+  const [isEdited, setIsEdited] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
+  const [error, setError] = useState(null);
+
+  const { data: session } = useSession();
+
+  if (!commentInfo || isDeleted) {
+    return <></>;
+  }
+
+  const handleEdit = () => {
+    commentInfo.comment = '테스트';
+    setIsEdited(true);
+  };
+
+  const handleDelete = async () => {
+    try {
+      setError(null);
+
+      const postId = commentInfo.blogPost;
+      const commentId = commentInfo._id;
+
+      const response = await axios.delete(
+        `/api/v1/comment/${postId}/${commentId}`,
+      );
+
+      if (response.data.status === 'success') {
+        setIsDeleted(true);
+      }
+    } catch (error) {
+      setError(error);
+    }
+  };
+
+  const isAuthor = session?.mongoId === commentInfo.author;
+
+  return (
+    <div className='border-t pt-4'>
+      <p className='mb-2'>{commentInfo.comment}</p>
+
+      <span className='text-gray-500'>
+        작성자: {commentInfo.author}
+        {isAuthor && (
+          <>
+            <button
+              onClick={handleEdit}
+              className='ml-2 text-sm text-gray-700 bg-gray-300 hover:bg-gray-400 py-1 px-2 rounded'
+            >
+              수정
+            </button>
+
+            <button
+              onClick={handleDelete}
+              className='ml-2 text-sm text-gray-700 bg-gray-300 hover:bg-gray-400 py-1 px-2 rounded'
+            >
+              삭제
+            </button>
+
+            {error && (
+              <span className='ml-2 text-red-500'>
+                댓글을 수정/삭제할 수 없습니다.
+              </span>
+            )}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+export default Comment;

--- a/src/components/Comment/CommentsSection.jsx
+++ b/src/components/Comment/CommentsSection.jsx
@@ -1,3 +1,5 @@
+import Comment from './Comment';
+
 function CommentsSection({
   comments,
   commentText,
@@ -7,12 +9,10 @@ function CommentsSection({
   return (
     <div>
       <h2 className='text-xl font-semibold mt-6 mb-4'>댓글</h2>
+
       {comments && comments.length ? (
         comments.map((comment) => (
-          <div key={comment._id} className='border-t pt-4'>
-            <p className='mb-2'>{comment.comment}</p>
-            <span className='text-gray-500'>작성자: {comment.author}</span>
-          </div>
+          <Comment key={comment._id} commentInfo={comment} />
         ))
       ) : (
         <p className='text-gray-500 mb-6'>아직 작성된 댓글이 없습니다.</p>
@@ -25,6 +25,7 @@ function CommentsSection({
           placeholder='댓글을 작성하세요.'
           className='w-full p-3 border rounded-md mb-4'
         />
+
         <button
           onClick={onCommentSubmit}
           className='mt-4 bg-logo text-white py-2 px-4 rounded'

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -53,9 +53,19 @@ const USER_NOT_LOGGED_IN = {
   MESSAGE: '해당 포스트의 작성자일 경우 로그인 후 이용 가능합니다.',
 };
 
+const COMMENT_USER_NOT_LOGGED_IN = {
+  STATUS_CODE: 401,
+  MESSAGE: '해당 댓글의 작성자일 경우 로그인 후 이용 가능합니다.',
+};
+
 const NOT_POST_AUTHOR = {
   STATUS_CODE: 403,
   MESSAGE: '포스트의 작성자가 아닙니다.',
+};
+
+const NOT_COMMENT_AUTHOR = {
+  STATUS_CODE: 403,
+  MESSAGE: '댓글의 작성자가 아닙니다.',
 };
 
 const UNAUTHORIZED_USER = {
@@ -76,5 +86,7 @@ export const ERRORS = {
   FILE_NOT_FOUND,
   USER_NOT_LOGGED_IN,
   NOT_POST_AUTHOR,
+  NOT_COMMENT_AUTHOR,
   UNAUTHORIZED_USER,
+  COMMENT_USER_NOT_LOGGED_IN,
 };


### PR DESCRIPTION
## 📝 PR 목적

댓글 삭제 api 구현

## 📑 작업 내용

- [x] 본인이 쓴 댓글 삭제 가능. 버튼 호버 시 색깔 어두워지도록 함. 삭제 버튼 누르면 즉시 목록에서 사라짐.
![image](https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133510836/2826f576-4418-43fa-b3ce-074ac23c3984)

- [x] 서버 측에서도 사용자 작성자 일치 검증. 클라이언트 측에서는 버튼 숨김.
![image](https://github.com/Last-Survivors-3-8/VanilLog-client/assets/133510836/802befbe-b227-49c0-bde9-2dc00aeb7ed9)


## 🚧 주의 사항

아직 댓글 수정 api는 구현되지 않았습니다.